### PR TITLE
Add support for creating OrderIntents with an existing patient

### DIFF
--- a/setupJest.ts
+++ b/setupJest.ts
@@ -34,7 +34,7 @@ async function mockFetch(url: FetchParams[0], config: FetchParams[1]) {
       // Only check patient email exists. That's enough to check the library handles errors properly.
       // Cast to a String to make TS happy
       const payload = JSON.parse(String(config.body));
-      if (!payload.patient) {
+      if (!(payload.patient || payload.patient_data)) {
         return {
           ok: false,
           status: 403,

--- a/src/api-client.test.ts
+++ b/src/api-client.test.ts
@@ -6,7 +6,7 @@ import { version } from "../package.json";
 
 const successfulPayload = {
   return_url: "https://example.com",
-  patient: {
+  patient_data: {
     first_name: "Ada",
     last_name: "Lovelace",
     email: "ada@rupahealth.com",

--- a/src/resources/order-intent.test.ts
+++ b/src/resources/order-intent.test.ts
@@ -3,7 +3,7 @@ import { getPublishableKey, minimalOrderIntentPayload } from "../test-utils";
 
 const fullPayload = {
   return_url: "https://example.com",
-  patient: {
+  patient_data: {
     first_name: "Ada",
     last_name: "Lovelace",
     email: "ada@rupahealth.com",
@@ -44,6 +44,27 @@ describe("OrderIntent resource", () => {
     const { status, orderIntent } = await rupa.orderIntents.create(
       minimalOrderIntentPayload
     );
+
+    // TS doesn't type guard on expect()
+    if (status !== "success") {
+      throw new Error("Assertion failed: expected status === success");
+    }
+
+    expect(orderIntent).toEqual({
+      id: "ordin_123abc",
+      redirect_url: "https://example.com",
+    });
+  });
+
+  test("Creates with existing patient", async () => {
+    const rupa = new Rupa(getPublishableKey);
+
+    // We're really just checking the types here as the mocking doesn't
+    // differentiate between the full and minimal payload.
+    const { status, orderIntent } = await rupa.orderIntents.create({
+      patient: "pat_123abc",
+      return_url: "https://example.com",
+    });
 
     // TS doesn't type guard on expect()
     if (status !== "success") {

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -4,7 +4,7 @@ export const getPublishableKey = async (key = "valid") => key;
 
 export const minimalOrderIntentPayload = {
   return_url: "https://example.com",
-  patient: {
+  patient_data: {
     first_name: "Ada",
     last_name: "Lovelace",
     email: "ada@rupahealth.com",

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,9 +59,16 @@ export type JSONSerializable =
   | JSONSerializable[]
   | { [key: string]: JSONSerializable };
 
-export interface OrderIntentRequestData {
+interface BaseOrderIntentRequestData {
   return_url: string;
-  patient: {
+  metadata?: {
+    [index: string]: JSONSerializable;
+  };
+}
+
+interface OrderIntentRequestDataWithPatientData
+  extends BaseOrderIntentRequestData {
+  patient_data: {
     first_name: string;
     last_name: string;
     email: string;
@@ -77,10 +84,16 @@ export interface OrderIntentRequestData {
       zipcode: string;
     };
   };
-  metadata?: {
-    [index: string]: JSONSerializable;
-  };
 }
+
+interface OrderIntentRequestDataWithPatientId
+  extends BaseOrderIntentRequestData {
+  patient: string;
+}
+
+export type OrderIntentRequestData =
+  | OrderIntentRequestDataWithPatientData
+  | OrderIntentRequestDataWithPatientId;
 
 export interface OrderIntent {
   id: string;


### PR DESCRIPTION
### Asana Ticket
https://app.asana.com/0/1202325525024084/1202325190745213

### What does this PR do?
Adds support for creating new order intents with an existing patient ID.

### How does it do it?
1. Renames the patient data field to `patient_data`.
2. Updates the OrderIntent request data interface to allow an ID to be given in `patient`.

### How did you test it?
Updated tests.