### PR TITLE
Add support for <script> loading

### DIFF
--- a/build.js
+++ b/build.js
@@ -11,10 +11,20 @@ const config = {
 build({
   ...config,
   outfile: "dist/index.js",
+  // Allows the library to be used via a <script> tag
+  format: "iife",
+  // This will save the module (in the format { default: Rupa(...)})
+  globalName: "__Rupa",
+  // As the default output is the module object, we extract that into a global
+  // `Rupa` variable so that users can do `const rupa = new Rupa(...)`
+  footer: {
+    js: "var Rupa = __Rupa.default",
+  },
 });
 
 build({
   ...config,
   outfile: "dist/index.esm.js",
+  // Allows the library to be used via esm + npm
   format: "esm",
 });

--- a/readme.md
+++ b/readme.md
@@ -36,9 +36,18 @@ element.setAttribute("href", orderIntent.redirect_url);
 ```
 
 ## Installation
+To install via npm:
 ```
 npm install @rupa-health/rupa-js
 ```
+
+To use in a script tag, you can use the library via a CDN:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@rupa-health/rupa-js@0.1.2/dist/index.js"></script>
+```
+
+**NOTE: Ensure you specify the library version**
 
 ## Usage
 


### PR DESCRIPTION
## Asana Ticket
https://app.asana.com/0/1202371097546555/1202400029862089

## What does this do?
Allows the library to be loaded via a <script> tag.

## How does it do it?
By default, `esbuild` outputs a browser-compatible `iife` format. This is what's used in the default `index.js` output in `dist/`. For npm, the `esm` format is used.

But for a user to be able to use `Rupa()` after loading the  script, our script needs to write to the global namespace. `esbuild` supports this via the `globalName` option. This will set the `entrypoint` module to the global variable specified. But as it sets the entire module as the global variable (`{ default: class Rupa { ... }}`), we need to use the `footer` option to set the `default` property to the global variable. 

So now a user simply needs to load the script via a CDN, then just use it via `const rupa = new Rupa(...)`.